### PR TITLE
修改了plugin文件中的正则表达式，以适用与~~~的代码块统计

### DIFF
--- a/mkdocs_statistics_plugin/plugin.py
+++ b/mkdocs_statistics_plugin/plugin.py
@@ -146,8 +146,8 @@ class StatisticsPlugin(BasePlugin):
         return chinese, english, codes
     
     def _clean_markdown(self, markdown: str) -> Tuple[str, list]:
-        codes = re.findall(r'```[^\n].*?```', markdown, re.S)
-        markdown = re.sub(r'```[^\n].*?```', '', markdown, flags=re.DOTALL | re.MULTILINE)
+        codes = re.findall(r'(~{3}.*~{3}|`{3}.*`{3})', markdown, re.S)
+        markdown = re.sub(r'(~{3}.*~{3}|`{3}.*`{3})', '', markdown, flags=re.DOTALL | re.MULTILINE)
         markdown = re.sub(r'<!--.*?-->', '', markdown, flags=re.DOTALL | re.MULTILINE)
         markdown = markdown.replace('\t', '    ')
         markdown = re.sub(r'[ ]{2,}', '    ', markdown)

--- a/mkdocs_statistics_plugin/plugin.py
+++ b/mkdocs_statistics_plugin/plugin.py
@@ -146,8 +146,8 @@ class StatisticsPlugin(BasePlugin):
         return chinese, english, codes
     
     def _clean_markdown(self, markdown: str) -> Tuple[str, list]:
-        codes = re.findall(r'(~~~[^\n].*~~~|```[^\n].*```)', markdown, re.S)
-        markdown = re.sub(r'(~~~[^\n].*~~~|```[^\n].*```)', '', markdown, flags=re.DOTALL | re.MULTILINE)
+        codes = re.findall(r'(~~~[^\n].*?~~~|```[^\n].*?```)', markdown, re.S)
+        markdown = re.sub(r'(~~~[^\n].*?~~~|```[^\n].*?```)', '', markdown, flags=re.DOTALL | re.MULTILINE)
         markdown = re.sub(r'<!--.*?-->', '', markdown, flags=re.DOTALL | re.MULTILINE)
         markdown = markdown.replace('\t', '    ')
         markdown = re.sub(r'[ ]{2,}', '    ', markdown)

--- a/mkdocs_statistics_plugin/plugin.py
+++ b/mkdocs_statistics_plugin/plugin.py
@@ -146,8 +146,8 @@ class StatisticsPlugin(BasePlugin):
         return chinese, english, codes
     
     def _clean_markdown(self, markdown: str) -> Tuple[str, list]:
-        codes = re.findall(r'(~{3}.*~{3}|`{3}.*`{3})', markdown, re.S)
-        markdown = re.sub(r'(~{3}.*~{3}|`{3}.*`{3})', '', markdown, flags=re.DOTALL | re.MULTILINE)
+        codes = re.findall(r'(~~~[^\n].*~~~|```[^\n].*```)', markdown, re.S)
+        markdown = re.sub(r'(~~~[^\n].*~~~|```[^\n].*```)', '', markdown, flags=re.DOTALL | re.MULTILINE)
         markdown = re.sub(r'<!--.*?-->', '', markdown, flags=re.DOTALL | re.MULTILINE)
         markdown = markdown.replace('\t', '    ')
         markdown = re.sub(r'[ ]{2,}', '    ', markdown)


### PR DESCRIPTION
原先代码
~~~Python
        codes = re.findall(r'```[^\n].*?```', markdown, re.S)
        markdown = re.sub(r'```[^\n].*?```', '', markdown, flags=re.DOTALL | re.MULTILINE)
~~~

结果
页面总数：27
总字数：15168
代码块行数：0
网站运行时间：1 年 246 天 6 小时 26 分钟

修改后
~~~Python
        codes = re.findall(r'(~{3}[^\n].*~{3}|`{3}[^\n].*`{3})', markdown, re.S)
        markdown = re.sub(r'(~{3}.[^\n]*~{3}|`{3}[^\n].*`{3})', '', markdown, flags=re.DOTALL | re.MULTILINE)
~~~

结果
页面总数：27
总字数：15168
代码块行数：141
网站运行时间：1 年 246 天 6 小时 26 分钟