### PR TITLE
feat: add page.meta info and in/exclude option, support material blog draft ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $ pip install . # or pip install -e .
 |`words_per_minute`|int|`300`|每分钟预计阅读字数|
 |`codelines_per_minute`|int|`80`|每分钟预计阅读代码行数|
 |`ignore_languages`|list|`["mermaid", "math"]`|不计入代码行数的语言列表|
+|`include_path`|str|` `|只统计匹配的路径（正则，路径相对 docs，为空则不启用）|
+|`exclude_path`|str|` `|不统计匹配的路径（正则，路径相对 docs，为空则不启用）|
 
 ### 几种使用方式
 #### 全局统计页

--- a/README.md
+++ b/README.md
@@ -89,5 +89,13 @@ plugins:
 
 具体细节见 plugin.py 中的 \_clean\_markdown 方法。
 
+#### 主题可用变量
+如果需要在模板中包含本页的统计信息或希望对统计信息进行更多控制，则可以在主题（模板）中使用保存于 `page.meta` 中的变量（仅在本页开启统计时可用）。
+| 变量 | 描述 |
+| --------------------------------------- | ---------- |
+| `page.meta.statistics_page_words`       | 本页预估字数 |
+| `page.meta.statistics_page_codes_lines` | 本页代码行数 |
+| `page.meta.statistics_page_read_time`   | 本页预估阅读时间（仅在本页开启统计阅读时间时可用） |
+
 ## 开发
 可能很不稳定（反正至少我能跑起来），有任何问题欢迎 issue 提出。同时页欢迎任何 PR，尽管提就好。

--- a/mkdocs_statistics_plugin/plugin.py
+++ b/mkdocs_statistics_plugin/plugin.py
@@ -136,6 +136,14 @@ class StatisticsPlugin(BasePlugin):
 
         if page.meta.get("hide") and "statistics" in page.meta["hide"]:
             return markdown
+        
+        include_path = self.config.get('include_path')
+        exclude_path = self.config.get('exclude_path')
+        src_path = page.file.src_path
+        if include_path and not re.match(include_path, src_path):
+            return markdown
+        if exclude_path and re.match(exclude_path, src_path):
+            return markdown
 
         page_check_metadata = self.config.get("page_check_metadata")
         if page_check_metadata == "" or page.meta.get(page_check_metadata):

--- a/mkdocs_statistics_plugin/plugin.py
+++ b/mkdocs_statistics_plugin/plugin.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import os
 import re
 import logging
@@ -39,6 +40,10 @@ class StatisticsPlugin(BasePlugin):
     words = 0
     codes = 0
 
+    is_serving = False
+    def on_startup(self, command, **kwargs):
+        self.is_serving = command == 'serve'
+
     def on_config(self, config: config_options.Config, **kwargs) -> Dict[str, Any]:
         page_template = self.config.get("page_template")
         if page_template == "":
@@ -53,23 +58,41 @@ class StatisticsPlugin(BasePlugin):
         include_path = self.config.get('include_path')
         exclude_path = self.config.get('exclude_path')
 
+        material_blog = config.get('plugins').get('material/blog')
+        if material_blog:
+            blog_config = material_blog.config
+            draft_always = blog_config.get('draft')
+            draft_on_serve = blog_config.get('draft_on_serve')
+            draft_if_future_date = blog_config.get('draft_if_future_date')
+
         for file in files.documentation_pages():
             src_path = file.src_path
+            
             if include_path and not re.match(include_path, src_path):
                 continue
             if exclude_path and re.match(exclude_path, src_path):
                 continue
+
+            with open(config['docs_dir'] + '/' + src_path, encoding='utf-8-sig', errors='strict') as f:
+                source = f.read()
+            markdown, meta = get_data(source)
+
+            post_date = meta.get('date')
+            if post_date and material_blog:  # date is require if it's a blog post
+                now = datetime.now()
+                is_draft = meta.get('draft', False) or (draft_if_future_date and post_date > now)
+                if draft_always:
+                    {}
+                elif not is_draft:
+                    {}
+                elif self.is_serving and draft_on_serve:
+                    {}
+                else: continue
+
             self.pages += 1
-            self._count_page(config['docs_dir'] + '/' + src_path)
+            self._words_count(markdown)
             
         return files
-
-    def _count_page(self, path: str) -> None:
-        with open(path, encoding='utf-8-sig', errors='strict') as f:
-            source = f.read()
-        markdown, _ = get_data(source)
-        self._words_count(markdown)
-        return
     
     def on_page_markdown(
         self, markdown: str, page: Page, config: config_options.Config, files, **kwargs

--- a/mkdocs_statistics_plugin/plugin.py
+++ b/mkdocs_statistics_plugin/plugin.py
@@ -55,6 +55,10 @@ class StatisticsPlugin(BasePlugin):
         return config
     
     def on_files(self, files: Files, *, config: config_options.Config) -> Optional[Files]:
+        self.pages = 0
+        self.words = 0
+        self.codes = 0
+
         include_path = self.config.get('include_path')
         exclude_path = self.config.get('exclude_path')
 

--- a/mkdocs_statistics_plugin/plugin.py
+++ b/mkdocs_statistics_plugin/plugin.py
@@ -130,6 +130,8 @@ class StatisticsPlugin(BasePlugin):
                     code_lines = code_lines,
                     read_time = read_time
                 )
+
+                page.meta["statistics_page_read_time"] = read_time
             else:
                 page_statistics_content = Template(self.template).render(
                     words = words,
@@ -137,6 +139,10 @@ class StatisticsPlugin(BasePlugin):
                 )
             lines.insert(h1 + 1, page_statistics_content)
             markdown = "\n".join(lines)
+
+            # Add to page meta information, for developers
+            page.meta["statistics_page_words"] = words
+            page.meta["statistics_page_codes_lines"] = code_lines
 
         return markdown
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 def read(fname):
     file_path = os.path.join(os.path.dirname(__file__), fname)
-    with open(file_path) as file:
+    with open(file_path, encoding="utf-8") as file:
         content = file.read()
     return content if content else 'no content read'
 


### PR DESCRIPTION
# 这个 PR 做了什么？

- [x] 在 `page.meta` 中附加本页的统计信息（Closes #14）
- [x] 增加 ”只统计匹配的路径或排除匹配的路径“ 选项
- [x] 支持对 Material for MkDocs 博客草稿的忽略（Closes #13）
