### PR TITLE
feat: the template can obtain configuration information

### DIFF
--- a/mkdocs_statistics_plugin/plugin.py
+++ b/mkdocs_statistics_plugin/plugin.py
@@ -192,6 +192,7 @@ class StatisticsPlugin(BasePlugin):
                 read_time = read_time,
                 page_read_time = self.config.get("page_read_time"),
                 page_images = self.config.get("page_images"),
+                config = config,
             )
 
             lines.insert(h1 + 1, page_statistics_content)


### PR DESCRIPTION
在渲染模板的地方加上了 `config` 变量，这样可以在模板里面获取到相关配置信息了。

这有什么用？有了 `config` 变量，用户可以通过类似下面的方式做到显示的文本根据构建时的语言自动更改，这对多语言的文档网站十分有帮助：

```jinja
<div class="statistics" markdown style="font-size: small; opacity: 0.7;">
{% if config.theme.language == 'zh' %}
显示中文内容
{% elif config.theme.language == 'en' %}
显示英文内容
{% endif %}
</div>
```

不只如此，或许还可以通过它来做到其它的功能，上面的只是举个例子。此外，`config` 本身就是函数 `on_page_markdown` 会传递的，因此我觉得加上它并不会造成什么额外的影响。